### PR TITLE
Docs update and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install --save-dev pull-request-size-reminder
 You can call the package from the command-line, through node.
 
 ```bash
-node pull-request-size-reminder
+npx pull-request-size-reminder
 ```
 
 The intended use is in conjunction with `husky` git hooks - `precommit` and/or `prepush`. Your project's `package.json` should be configured as below.
@@ -37,7 +37,7 @@ The intended use is in conjunction with `husky` git hooks - `precommit` and/or `
 ```javascript
 {
   "scripts": {
-    "precommit": "node pull-request-size-reminder"
+    "precommit": "npx pull-request-size-reminder"
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request-size-reminder",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "CLI to check potential size of pull request",
   "keywords": [
     "git",


### PR DESCRIPTION
updated the docs to reference `npx` to directly run the package
bumped the version for a publish